### PR TITLE
Change timestep to chrono

### DIFF
--- a/engine/src/engine/Application.cpp
+++ b/engine/src/engine/Application.cpp
@@ -4,13 +4,13 @@
 
 #include "Log.h"
 #include "Input.h"
-
+#include <chrono>
 namespace Engine {
 
 #define BIND_EVENT_FN(x) std::bind(&Application::x, this, std::placeholders::_1)
-  
+
   Application* Application::s_Instance = nullptr;
-   
+
   Application::Application()
   {
     BE_INFO("Creating application");
@@ -60,7 +60,7 @@ namespace Engine {
 
   void Application::Run(){
     while(m_Running){
-      float time = glfwGetTime(); // TODO: Platform!
+      Timestep time{glfwGetTime()}; // TODO: Platform!
       Timestep timestep = time - m_FrameLastTime;
       m_FrameLastTime = time;
 

--- a/engine/src/engine/Application.h
+++ b/engine/src/engine/Application.h
@@ -47,7 +47,7 @@ namespace Engine {
       ImGUILayer* m_ImGuiLayer;
       bool m_Running = true;
       LayerStack m_LayerStack;
-      Timestep m_FrameLastTime;
+      Timestep m_FrameLastTime{0.f};
       static Application* s_Instance;
   };
 

--- a/engine/src/engine/Application.h
+++ b/engine/src/engine/Application.h
@@ -15,6 +15,7 @@
 #include "LayerStack.h"
 
 #include "engine/renderer/OrthographicCamera.h"
+#include "engine/core/Timestep.h"
 
 namespace Engine {
   /**
@@ -29,15 +30,15 @@ namespace Engine {
        */
       Application();
       virtual ~Application();
-      
+
       void Run();
 
       void OnEvent(Event& e);
 
       void PushLayer(Layer* layer);
       void PushOverlay(Layer* overlay);
-     
-      bool IsRunning() const { return m_Running; } 
+
+      bool IsRunning() const { return m_Running; }
       inline static Application& Get() { return *s_Instance; };
       inline Window& GetWindow() { return *m_Window; };
     private:
@@ -46,10 +47,10 @@ namespace Engine {
       ImGUILayer* m_ImGuiLayer;
       bool m_Running = true;
       LayerStack m_LayerStack;
-      float m_FrameLastTime = 0.0f;
+      Timestep m_FrameLastTime;
       static Application* s_Instance;
   };
-  
+
   // TODO: by client
   Application* CreateApplication();
 }

--- a/engine/src/engine/Core.h
+++ b/engine/src/engine/Core.h
@@ -38,41 +38,37 @@ namespace Engine {
 #endif
 }
 
+namespace Engine {
 //jnl from http://blog.bitwigglers.org/using-enum-classes-as-type-safe-bitmasks/
 //    this enables us to use a type-safe bitmask with enum class
-template<typename Enum>
-struct EnableBitMaskOperators
-{
-  static const bool enable = false;
-};
+  template<typename Enum>
+  struct EnableBitMaskOperators {
+    static const bool enable = false;
+  };
 
-template<typename Enum>
-typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
-operator |(Enum lhs, Enum rhs)
-{
-  using underlying = typename std::underlying_type<Enum>::type;
-  return static_cast<Enum> (
-    static_cast<underlying>(lhs) |
-    static_cast<underlying>(rhs)
+  template<typename Enum>
+  typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+  operator|(Enum lhs, Enum rhs) {
+    using underlying = typename std::underlying_type<Enum>::type;
+    return static_cast<Enum> (
+        static_cast<underlying>(lhs) |
+        static_cast<underlying>(rhs)
     );
-}
+  }
 
-template<typename Enum>
-typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
-operator &(Enum lhs, Enum rhs)
-{
-  using underlying = typename std::underlying_type<Enum>::type;
-  return static_cast<Enum> (
-    static_cast<underlying>(lhs) &
-    static_cast<underlying>(rhs)
+  template<typename Enum>
+  typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+  operator&(Enum lhs, Enum rhs) {
+    using underlying = typename std::underlying_type<Enum>::type;
+    return static_cast<Enum> (
+        static_cast<underlying>(lhs) &
+        static_cast<underlying>(rhs)
     );
+  }
 }
-
 #define ENABLE_BITMASK_OPERATORS(x)  \
 template<>                           \
 struct EnableBitMaskOperators<x>     \
 {                                    \
   static const bool enable = true; \
 };
-
-

--- a/engine/src/engine/Core.h
+++ b/engine/src/engine/Core.h
@@ -38,6 +38,41 @@ namespace Engine {
 #endif
 }
 
+//jnl from http://blog.bitwigglers.org/using-enum-classes-as-type-safe-bitmasks/
+//    this enables us to use a type-safe bitmast with enum class
+template<typename Enum>
+struct EnableBitMaskOperators
+{
+  static const bool enable = false;
+};
 
+template<typename Enum>
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+operator |(Enum lhs, Enum rhs)
+{
+  using underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum> (
+    static_cast<underlying>(lhs) |
+    static_cast<underlying>(rhs)
+    );
+}
+
+template<typename Enum>
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+operator &(Enum lhs, Enum rhs)
+{
+  using underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum> (
+    static_cast<underlying>(lhs) &
+    static_cast<underlying>(rhs)
+    );
+}
+
+#define ENABLE_BITMASK_OPERATORS(x)  \
+template<>                           \
+struct EnableBitMaskOperators<x>     \
+{                                    \
+  static const bool enable = true; \
+};
 
 

--- a/engine/src/engine/Core.h
+++ b/engine/src/engine/Core.h
@@ -39,7 +39,7 @@ namespace Engine {
 }
 
 //jnl from http://blog.bitwigglers.org/using-enum-classes-as-type-safe-bitmasks/
-//    this enables us to use a type-safe bitmast with enum class
+//    this enables us to use a type-safe bitmask with enum class
 template<typename Enum>
 struct EnableBitMaskOperators
 {

--- a/engine/src/engine/Layer.h
+++ b/engine/src/engine/Layer.h
@@ -5,7 +5,7 @@
 #include "engine/core/Timestep.h"
 
 namespace Engine {
-  
+
   class BE_API Layer
   {
     public:

--- a/engine/src/engine/core/Timestep.h
+++ b/engine/src/engine/core/Timestep.h
@@ -1,40 +1,8 @@
 #pragma once
 
-namespace Engine {
-  /**
-   * Timestep class, holds
-   */
-  class Timestep
-  {
-  public:
+#include<chrono>
 
-    /**
-     * Default constructor
-     * @param time: time unit in Seconds
-     */
-    Timestep(float time = 0.0f)
-    :m_Time(time)
-    { }
-
-    /**
-     * Cast to float
-     * @return m_Time (Seconds)
-     */
-    operator float() const { return m_Time; };
-
-    /**
-     * Getter for Seconds
-     * @return m_Time (in Seconds)
-     */
-    float GetSeconds() { return m_Time; };
-
-    /**
-     * Getter for Milliseconds
-     * @returns m_Time in Milliseconds
-     */
-    float GetMilliseconds() { return m_Time * 1000.0f; };
-
-  private:
-    float m_Time; /*!<  time unit in Seconds */
-  };
+namespace Engine
+{
+  typedef std::chrono::duration<float> Timestep;
 }

--- a/engine/src/engine/events/ApplicationEvent.h
+++ b/engine/src/engine/events/ApplicationEvent.h
@@ -18,7 +18,7 @@ namespace Engine {
       }
 
       EVENT_CLASS_TYPE(WindowResize)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
     private:
       unsigned int m_Width, m_Height;
   };
@@ -29,7 +29,7 @@ namespace Engine {
       WindowCloseEvent() {}
 
       EVENT_CLASS_TYPE(WindowClose)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
   class BE_API WindowMovedEvent: public Event
   {
@@ -37,7 +37,7 @@ namespace Engine {
       WindowMovedEvent() {}
 
       EVENT_CLASS_TYPE(WindowMoved)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
 
   class BE_API WindowFocusEvent: public Event
@@ -46,7 +46,7 @@ namespace Engine {
       WindowFocusEvent() {}
 
       EVENT_CLASS_TYPE(WindowFocus)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
 
   class BE_API WindowLostFocusEvent: public Event
@@ -55,7 +55,7 @@ namespace Engine {
       WindowLostFocusEvent() {}
 
       EVENT_CLASS_TYPE(WindowLostFocus)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
 
 
@@ -65,7 +65,7 @@ namespace Engine {
       AppTickEvent() {}
 
       EVENT_CLASS_TYPE(AppTick)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
 
   class BE_API AppUpdateEvent: public Event
@@ -74,7 +74,7 @@ namespace Engine {
       AppUpdateEvent() {}
 
       EVENT_CLASS_TYPE(AppUpdate)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
 
   class BE_API AppRenderEvent: public Event
@@ -83,6 +83,6 @@ namespace Engine {
       AppRenderEvent() {}
 
       EVENT_CLASS_TYPE(AppRender)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::Application)
   };
 }

--- a/engine/src/engine/events/ApplicationEvent.h
+++ b/engine/src/engine/events/ApplicationEvent.h
@@ -18,7 +18,7 @@ namespace Engine {
       }
 
       EVENT_CLASS_TYPE(WindowResize)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
     private:
       unsigned int m_Width, m_Height;
   };
@@ -29,7 +29,7 @@ namespace Engine {
       WindowCloseEvent() {}
 
       EVENT_CLASS_TYPE(WindowClose)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
   class BE_API WindowMovedEvent: public Event
   {
@@ -37,7 +37,7 @@ namespace Engine {
       WindowMovedEvent() {}
 
       EVENT_CLASS_TYPE(WindowMoved)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
 
   class BE_API WindowFocusEvent: public Event
@@ -46,7 +46,7 @@ namespace Engine {
       WindowFocusEvent() {}
 
       EVENT_CLASS_TYPE(WindowFocus)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
 
   class BE_API WindowLostFocusEvent: public Event
@@ -55,7 +55,7 @@ namespace Engine {
       WindowLostFocusEvent() {}
 
       EVENT_CLASS_TYPE(WindowLostFocus)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
 
 
@@ -65,7 +65,7 @@ namespace Engine {
       AppTickEvent() {}
 
       EVENT_CLASS_TYPE(AppTick)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
 
   class BE_API AppUpdateEvent: public Event
@@ -74,7 +74,7 @@ namespace Engine {
       AppUpdateEvent() {}
 
       EVENT_CLASS_TYPE(AppUpdate)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
 
   class BE_API AppRenderEvent: public Event
@@ -83,6 +83,6 @@ namespace Engine {
       AppRenderEvent() {}
 
       EVENT_CLASS_TYPE(AppRender)
-      EVENT_CLASS_CATEGORY(EventCategoryApplication)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryApplication)
   };
 }

--- a/engine/src/engine/events/Event.h
+++ b/engine/src/engine/events/Event.h
@@ -15,7 +15,8 @@ namespace Engine {
     MouseButtonPressed, MouseButtonReleased, MouseMoved, MouseScrolled
   };
 
-  enum EventCategory {
+  enum class EventCategory
+  {
     None = 0,
     EventCategoryApplication = BIT(0),
     EventCategoryInput = BIT(1),
@@ -23,6 +24,7 @@ namespace Engine {
     EventCategoryMouse = BIT(3),
     EventCategoryMouseButton = BIT(4),
   };
+  ENABLE_BITMASK_OPERATORS(EventCategory)
 
 #ifndef EVENT_CLASS_TYPE
   #define EVENT_CLASS_TYPE(type) static EventType GetStaticType(){return Engine::EventType::type; }\
@@ -30,7 +32,7 @@ namespace Engine {
       virtual const char* GetName() const override {return #type;}
 #endif
 #ifndef EVENT_CLASS_CATEGORY
-  #define EVENT_CLASS_CATEGORY(category) virtual int GetCategoryFlags() const override {return category;}
+  #define EVENT_CLASS_CATEGORY(category) virtual EventCategory GetCategoryFlags() const override {return category;}
 #endif
   class BE_API Event
   {
@@ -38,11 +40,11 @@ namespace Engine {
   public:
     virtual EventType GetEventType() const = 0;
     virtual const char *GetName() const = 0;
-    virtual int GetCategoryFlags() const = 0;
+    virtual EventCategory GetCategoryFlags() const = 0;
     virtual std::string ToString() const { return GetName(); }
 
     inline bool IsInCategory(EventCategory category){
-      return GetCategoryFlags() && category;
+      return static_cast<bool>(GetCategoryFlags() & category);
     }
     bool Handled = false;
 

--- a/engine/src/engine/events/Event.h
+++ b/engine/src/engine/events/Event.h
@@ -18,11 +18,11 @@ namespace Engine {
   enum class EventCategory
   {
     None = 0,
-    EventCategoryApplication = BIT(0),
-    EventCategoryInput = BIT(1),
-    EventCategoryKeyboard = BIT(2),
-    EventCategoryMouse = BIT(3),
-    EventCategoryMouseButton = BIT(4),
+    Application = BIT(0),
+    Input = BIT(1),
+    Keyboard = BIT(2),
+    Mouse = BIT(3),
+    MouseButton = BIT(4),
   };
   ENABLE_BITMASK_OPERATORS(EventCategory)
 

--- a/engine/src/engine/events/KeyEvent.h
+++ b/engine/src/engine/events/KeyEvent.h
@@ -10,7 +10,7 @@ namespace Engine {
     public:
       inline int GetKeyCode() const {return m_KeyCode; }
 
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryKeyboard | EventCategory::EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::Keyboard | EventCategory::Input)
     protected:
         KeyEvent(int keycode)
           : m_KeyCode(keycode) {}

--- a/engine/src/engine/events/KeyEvent.h
+++ b/engine/src/engine/events/KeyEvent.h
@@ -4,13 +4,13 @@
 
 
 namespace Engine {
-  
+
   class BE_API KeyEvent: public Event
   {
     public:
       inline int GetKeyCode() const {return m_KeyCode; }
 
-      EVENT_CLASS_CATEGORY(EventCategoryKeyboard | EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryKeyboard | EventCategory::EventCategoryInput)
     protected:
         KeyEvent(int keycode)
           : m_KeyCode(keycode) {}
@@ -27,8 +27,8 @@ namespace Engine {
 
       std::string ToString() const override {
         std::stringstream ss;
-        ss << "KeyPressedEvent: " << m_KeyCode << " ( " << m_RepeatCount << " repeats)"; 
-        return ss.str();  
+        ss << "KeyPressedEvent: " << m_KeyCode << " ( " << m_RepeatCount << " repeats)";
+        return ss.str();
       }
 
       EVENT_CLASS_TYPE(KeyPressed)
@@ -44,8 +44,8 @@ namespace Engine {
 
       std::string ToString() const override {
         std::stringstream ss;
-        ss << "KeyReleasedEvent: " << m_KeyCode; 
-        return ss.str();  
+        ss << "KeyReleasedEvent: " << m_KeyCode;
+        return ss.str();
       }
       EVENT_CLASS_TYPE(KeyReleased)
   };

--- a/engine/src/engine/events/MouseEvent.h
+++ b/engine/src/engine/events/MouseEvent.h
@@ -20,7 +20,7 @@ namespace Engine {
       }
 
       EVENT_CLASS_TYPE(MouseMoved)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryMouse | EventCategory::EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::Mouse | EventCategory::Input)
     protected:
       float m_MouseX, m_MouseY;
   };
@@ -41,7 +41,7 @@ namespace Engine {
       }
 
       EVENT_CLASS_TYPE(MouseScrolled)
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryMouse | EventCategory::EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::Mouse | EventCategory::Input)
     private:
       float m_XOffset, m_YOffset;
   };
@@ -51,7 +51,7 @@ namespace Engine {
     public:
       inline int GetMouseButton() const { return m_Button; }
 
-      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryMouseButton | EventCategory::EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::MouseButton | EventCategory::Input)
     protected:
       MouseButtonEvent(int button)
         : m_Button(button) {}

--- a/engine/src/engine/events/MouseEvent.h
+++ b/engine/src/engine/events/MouseEvent.h
@@ -3,7 +3,7 @@
 #include "Event.h"
 
 namespace Engine {
-  
+
   class BE_API MouseMovedEvent: public Event
   {
     public:
@@ -12,7 +12,7 @@ namespace Engine {
 
       inline float GetX() const { return m_MouseX; }
       inline float GetY() const { return m_MouseY; }
-      
+
       std::string ToString() const override {
         std::stringstream ss;
         ss << "MouseMovedEvent: " << GetX() << ", " << GetY();
@@ -20,7 +20,7 @@ namespace Engine {
       }
 
       EVENT_CLASS_TYPE(MouseMoved)
-      EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryMouse | EventCategory::EventCategoryInput)
     protected:
       float m_MouseX, m_MouseY;
   };
@@ -41,7 +41,7 @@ namespace Engine {
       }
 
       EVENT_CLASS_TYPE(MouseScrolled)
-      EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryMouse | EventCategory::EventCategoryInput)
     private:
       float m_XOffset, m_YOffset;
   };
@@ -50,8 +50,8 @@ namespace Engine {
   {
     public:
       inline int GetMouseButton() const { return m_Button; }
-      
-      EVENT_CLASS_CATEGORY(EventCategoryMouseButton | EventCategoryInput)
+
+      EVENT_CLASS_CATEGORY(EventCategory::EventCategoryMouseButton | EventCategory::EventCategoryInput)
     protected:
       MouseButtonEvent(int button)
         : m_Button(button) {}

--- a/engine/src/engine/renderer/Mesh.h
+++ b/engine/src/engine/renderer/Mesh.h
@@ -58,8 +58,6 @@ namespace Engine {
       VertexCategoryNormal = BIT(2),
     };
     explicit ObjFile() {}
-    // Warning	C26495	Variable 'Engine::ObjFile::file' is uninitialized. Always initialize a member variable (type.6).
-
 
     explicit ObjFile(const std::string& fp);
     inline void Open(const char* mode="r") { file = fopen(filePath.c_str(), mode);}
@@ -79,7 +77,7 @@ namespace Engine {
     bool LoadObjFile(std::string const& fileName);
 
   private:
-    FILE* file;
+    FILE* file = nullptr;
     std::string filePath;
     std::vector<glm::vec3> vertices;
     std::vector<glm::vec3> normals;

--- a/engine/src/engine/renderer/Mesh.h
+++ b/engine/src/engine/renderer/Mesh.h
@@ -58,6 +58,8 @@ namespace Engine {
       VertexCategoryNormal = BIT(2),
     };
     explicit ObjFile() {}
+    // Warning	C26495	Variable 'Engine::ObjFile::file' is uninitialized. Always initialize a member variable (type.6).
+
 
     explicit ObjFile(const std::string& fp);
     inline void Open(const char* mode="r") { file = fopen(filePath.c_str(), mode);}

--- a/engine/src/engine/renderer/OrthographicCamera.cpp
+++ b/engine/src/engine/renderer/OrthographicCamera.cpp
@@ -20,7 +20,7 @@ namespace Engine {
   Camera::CameraStack* Camera::camStack = new Camera::CameraStack();
   Camera::Camera(glm::mat4 projection, glm::mat4 view)
       : m_ProjectionMatrix(projection), m_ViewMatrix(view),
-        m_ViewProjectionMatrix(m_ProjectionMatrix * m_ViewMatrix) 
+        m_ViewProjectionMatrix(m_ProjectionMatrix * m_ViewMatrix)
   {
     camStack->AddCamera(this);
   };
@@ -63,7 +63,8 @@ namespace Engine {
   }
 
 
-  void ThirdPersonCamera::OnUpdate(Timestep &ts) {
+  void ThirdPersonCamera::OnUpdate(Timestep& tsr) {
+  const float ts = tsr.count();
     {
       if (Input::IsKeyPressed(BE_KEY_LEFT)) {
         ProcessMouseMovement(m_Speed * 100.0f * ts, 0);

--- a/engine/src/engine/renderer/OrthographicCamera.h
+++ b/engine/src/engine/renderer/OrthographicCamera.h
@@ -13,7 +13,7 @@ namespace Engine {
   const float SPEED = 2.5f;
   const float SENSITIFITY = 0.05f;
   const float ZOOM = 45.0f;
-  
+
 
   class Camera
   {
@@ -45,7 +45,7 @@ namespace Engine {
     virtual void OnUpdate(Timestep &ts) = 0;
     glm::vec3& GetPosition() {return m_Position; };
     glm::vec2 GetRotation() const { return m_Rotation; };
-    
+
     const glm::mat4& GetProjectionMatrix() { return m_ProjectionMatrix; };
     const glm::mat4& GetViewMatrix() { return m_ViewMatrix; };
     const glm::mat4& GetViewProjectionMatrix() { return m_ViewProjectionMatrix; };
@@ -66,7 +66,7 @@ namespace Engine {
     float m_Speed = 10.0f;
     bool m_IsActive = true;
   };
-  
+
   class OrthographicCamera: public Camera
   {
   public:
@@ -75,7 +75,7 @@ namespace Engine {
   private:
     virtual void RecalculateViewMatrix() override;
   };
-  
+
   class ThirdPersonCamera: public Camera
   {
   public:
@@ -87,7 +87,7 @@ namespace Engine {
 
   private:
     virtual void RecalculateViewMatrix() override;
-    
+
     glm::vec3 m_Target;
     glm::vec3 m_Front;
     glm::vec3 m_Direction;

--- a/engine/src/platform/opengl/OpenGLVertexArray.cpp
+++ b/engine/src/platform/opengl/OpenGLVertexArray.cpp
@@ -58,8 +58,7 @@ namespace Engine {
           ShaderDataTypeToOpenGLBaseType(element.Type),
           element.Normalized ? GL_TRUE : GL_FALSE,
           layout.GetStride(),
-          (const void*) element.Offset
-          //warning	c4312	'type cast': conversion from 'const uint32_t' to 'const void *' of greater size
+          (const void *)(uint64_t) element.Offset
         );
         index++;
       }

--- a/engine/tests/core/test_timestep.h
+++ b/engine/tests/core/test_timestep.h
@@ -22,39 +22,38 @@ void TestTimestep()
   Tester::addTest([=]()
   {
     Timestep t;
-    BE_TEST_ONCE(t.GetMilliseconds() == 0);
+    BE_TEST_ONCE(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{0.f});
   });
   Tester::addTest([=]()
   {
     Timestep t;
-    BE_TEST_ONCE(t.GetSeconds() == 0);
+    BE_TEST_ONCE(t.count() == 0);
   });
   Tester::addTest([=]()
   {
     Timestep t(1.0f);
-    BE_TEST_ONCE(t.GetSeconds() == 1.0f);
+    BE_TEST_ONCE(t.count() == 1.0f);
   });
   Tester::addTest([=]()
   {
     Timestep t(1.0f);
-    BE_TEST_ONCE(t.GetMilliseconds() == 1000.0f);
+    BE_TEST_ONCE(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{1000.0f});
   });
   Tester::addTest([=]()
   {
     Timestep t;
-    t = t + 1;
-    BE_TEST_MULTI(t.GetSeconds() == 1.0f);
-    BE_TEST_ONCE(t.GetMilliseconds() == 1000.0f);
-    //Warning	C4715	'<lambda_bb557d9c8f4837619b6480b6a60b4f65>::operator()': not all control paths return a value
+    t++;
+    BE_TEST_MULTI(t.count() == 1.0f);
+    BE_TEST_MULTI(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{1000.0f});
+    return test_status::TEST_OK;
   });
   Tester::addTest([=]()
   {
-    Timestep t(1.0);
-    t = t - 1;
-    BE_TEST_MULTI(t.GetSeconds() == 0.0f);
-    BE_TEST_ONCE(t.GetMilliseconds() == 0.0f);
-    //Warning	C4715	'<lambda_812a0c0e34e59e1725d88879a760847b>::operator()': not all control paths return a value
-
+    Timestep t(1.0f);
+    t--;
+    BE_TEST_MULTI(t.count() == 0.0f);
+    BE_TEST_MULTI(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{0.f});
+    return test_status::TEST_OK;
   });
 
   /**
@@ -62,19 +61,23 @@ void TestTimestep()
     * for real usage see `Engine::Application`s implementation of the
     * main game loop.
     */
-  auto deltaProducer = [=](float &ts){float fps = 60.0f;ts = (1000.f/fps);};
+  auto deltaProducer = [=](Timestep &ts)
+  {
+    const Timestep fps{60.0f};
+    ts = (fps * 1/1000.f);
+  };
 
   Tester::addTest([=]()
   {
     Timestep t;
     float fps = 60.0f;
-    float delta;
+    Timestep delta;
     for(int i=0; i<10; ++i){
       deltaProducer(delta);
       t = t + delta;
     }
-    float frameTime = 1000.f/fps;
-    BE_TEST_ONCE(t - (10.0f * frameTime) <= 0.0001);
-    //Warning	C4715	'<lambda_d46812fce8d74eb6faf7b7105a2d707d>::operator()': not all control paths return a value
+    Timestep frameTime{1000.f/fps};
+    BE_TEST_MULTI(t - (10.0f * frameTime) <= Timestep{0.0001f});
+    return test_status::TEST_OK;
   });
 }

--- a/engine/tests/core/test_timestep.h
+++ b/engine/tests/core/test_timestep.h
@@ -21,12 +21,12 @@ void TestTimestep()
   using namespace Engine;
   Tester::addTest([=]()
   {
-    Timestep t;
+    Timestep t{0.f};
     BE_TEST_ONCE(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{0.f});
   });
   Tester::addTest([=]()
   {
-    Timestep t;
+    Timestep t{0.f};
     BE_TEST_ONCE(t.count() == 0);
   });
   Tester::addTest([=]()
@@ -37,19 +37,19 @@ void TestTimestep()
   Tester::addTest([=]()
   {
     Timestep t(1.0f);
-    BE_TEST_ONCE(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{1000.0f});
+    BE_TEST_ONCE(std::chrono::duration_cast<std::chrono::milliseconds>(t).count() == 1000.f);
   });
   Tester::addTest([=]()
   {
-    Timestep t;
+    Timestep t{0.f};
     t++;
     BE_TEST_MULTI(t.count() == 1.0f);
-    BE_TEST_MULTI(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{1000.0f});
+    BE_TEST_MULTI(std::chrono::duration_cast<std::chrono::milliseconds>(t).count() == 1000.f);
     return test_status::TEST_OK;
   });
   Tester::addTest([=]()
   {
-    Timestep t(1.0f);
+    Timestep t{1.f};
     t--;
     BE_TEST_MULTI(t.count() == 0.0f);
     BE_TEST_MULTI(std::chrono::duration_cast<std::chrono::milliseconds>(t) == Timestep{0.f});

--- a/sandbox/src/GameWorld.h
+++ b/sandbox/src/GameWorld.h
@@ -48,6 +48,8 @@ GameWorld::GameWorld(Engine::Ref<Engine::VertexBuffer> vb, Engine::Ref<Engine::I
   m_Mesh = Engine::Mesh::Create(vb, ib, "sandbox/assets/shaders/World.glsl");
 }
 void GameWorld::GenerateVertices(const std::string &fileName) {
+// Warning	C6262	Function uses '921780' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.
+
   const int rowCount = 80;
   const int columnCount = rowCount;
   const int verticesForSquare = 6;

--- a/sandbox/src/SandboxApp.cpp
+++ b/sandbox/src/SandboxApp.cpp
@@ -146,17 +146,18 @@ class ExampleLayer: public Engine::Layer
     }
 
     void OnUpdate(Engine::Timestep ts) override {
+    const float ts_float = ts.count();
       Engine::Renderer::BeginScene(m_PlayerCameraLayer.GetCamera());
       {
         if (Engine::Input::IsKeyPressed(BE_KEY_J)) {
-          m_SquarePosition.x += m_SquareMoveSpeed * ts;
+          m_SquarePosition.x += m_SquareMoveSpeed * ts_float;
         } else if (Engine::Input::IsKeyPressed(BE_KEY_L)) {
-          m_SquarePosition.x -= m_SquareMoveSpeed * ts;
+          m_SquarePosition.x -= m_SquareMoveSpeed * ts_float;
         }
         if (Engine::Input::IsKeyPressed(BE_KEY_I)) {
-          m_SquarePosition.y -= m_SquareMoveSpeed * ts;
+          m_SquarePosition.y -= m_SquareMoveSpeed * ts_float;
         } else if (Engine::Input::IsKeyPressed(BE_KEY_K)) {
-          m_SquarePosition.y += m_SquareMoveSpeed * ts;
+          m_SquarePosition.y += m_SquareMoveSpeed * ts_float;
         }
       }
       Engine::RenderCommand::SetClearColor({ 0.1f, 0.1f, 0.1f, 1});
@@ -211,7 +212,7 @@ class ExampleLayer: public Engine::Layer
       if(objects[Objects::Cube3D]) m_Cube->OnUpdate(ts);
       if(objects[Objects::Suzanne]) m_Suzanne->OnUpdate(ts);
 //      for(const auto& obj : m_Models){
-//        obj->OnUpdate(ts);
+//        obj->OnUpdate(ts_float);
 //      }
       m_PlayerCameraLayer.OnUpdate(ts);
 


### PR DESCRIPTION
moving forward the tests for Timestep can be removed, i left them for you to read and understand what `std::chrono::duration` does and how to use it.

the benefit of a `std::chrono::duration` is that it can implicitly convert between milliseconds and seconds etc. (for example to compare two values) so it is safe to use like that. it can also not be implicitly cast to its template type (float), so one has to always use the correct type and can be sure that the amount of time one is given in a function is correct.

`typedef std::chrono::duration<float> Timestep` means a Timestep of one is one second, since the second template argument is defaulting to one